### PR TITLE
Kubeadm

### DIFF
--- a/install_controlplane.yaml
+++ b/install_controlplane.yaml
@@ -1,5 +1,16 @@
 ---
 - name: Install common dependencies
   hosts: controlplane
+  pre_tasks:
+    - name: get ip address
+      local_action:
+        module: amazon.aws.ec2_instance_info
+        region: eu-central-1
+        filters:
+          "tag:role": "controlplane"
+      register: controlplane_info
+      run_once: true
+  vars:
+    common_controlplane_ip: "{{ controlplane_info.instances[0].private_ip_address }}"
   roles:
     - common

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -2,4 +2,4 @@
 common_containerd_version: "1.7.7"
 common_runc_version: "1.1.9"
 common_cni_plugins_version: "1.3.0"
-common_controllplane_ip: "127.0.0.1"
+common_controlplane_ip: "127.0.0.1"

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
-containerd_version: "1.7.7"
-runc_version: "1.1.9"
-cni_plugins_version: "1.3.0"
+common_containerd_version: "1.7.7"
+common_runc_version: "1.1.9"
+common_cni_plugins_version: "1.3.0"
+common_controllplane_ip: "127.0.0.1"

--- a/roles/common/tasks/containerd.yml
+++ b/roles/common/tasks/containerd.yml
@@ -1,8 +1,8 @@
 # containerd tasks
-- name: "Download containerd v{{containerd_version}}"
+- name: "Download containerd v{{common_containerd_version}}"
   ansible.builtin.get_url:
     dest: "{{common_ansible_directory}}/{{common_containerd_tar}}"
-    url: "https://github.com/containerd/containerd/releases/download/v{{containerd_version}}/{{common_containerd_tar}}"
+    url: "https://github.com/containerd/containerd/releases/download/v{{common_containerd_version}}/{{common_containerd_tar}}"
   register: containerd_download
 
 - name: "Extract containerd"
@@ -31,9 +31,9 @@
   become: true
 
 # runc tasks
-- name: "Install runc v{{runc_version}}"
+- name: "Install runc v{{common_runc_version}}"
   ansible.builtin.get_url:
-    url: "https://github.com/opencontainers/runc/releases/download/v{{runc_version}}/runc.amd64"
+    url: "https://github.com/opencontainers/runc/releases/download/v{{common_runc_version}}/runc.amd64"
     dest: /usr/local/sbin/runc
     mode: 0755
   register: install_runc
@@ -48,9 +48,9 @@
     mode: 0755
   become: true
 
-- name: "Install cni-plugins v{{cni_plugins_version}}"
+- name: "Install cni-plugins v{{common_cni_plugins_version}}"
   ansible.builtin.unarchive:
-    src: "https://github.com/containernetworking/plugins/releases/download/v{{cni_plugins_version}}/cni-plugins-linux-amd64-v{{cni_plugins_version}}.tgz"
+    src: "https://github.com/containernetworking/plugins/releases/download/v{{common_cni_plugins_version}}/cni-plugins-linux-amd64-v{{common_cni_plugins_version}}.tgz"
     creates: /opt/cni/bin/bridge
     dest: /opt/cni/bin/
     remote_src: yes

--- a/roles/common/tasks/k8s.yml
+++ b/roles/common/tasks/k8s.yml
@@ -1,0 +1,31 @@
+- name: Install k8s repository key
+  ansible.builtin.apt_key:
+    url: https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key
+    keyring: "{{ common_k8s_keyring_path }}"
+    state: present
+  become: true
+
+- name: Install k8s repository
+  ansible.builtin.apt_repository:
+    repo: deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /
+    state: present
+    update_cache: true
+    filename: kubernetes
+  become: true
+
+- name: Install k8s packages
+  ansible.builtin.apt:
+    pkg:
+      - kubelet
+      - kubeadm
+      - kubectl
+    state: present
+  become: true
+  register: install_k8s_packages
+
+- name: Mark hold k8s packages
+  ansible.builtin.command:
+    cmd: apt-mark hold kubelet kubeadm kubectl
+  become: true
+  when: install_k8s_packages is changed
+

--- a/roles/common/tasks/linux.yml
+++ b/roles/common/tasks/linux.yml
@@ -12,3 +12,13 @@
     dest: /etc/sysctl.d/k8s.conf
   become: true
   notify: "Apply sysctl conf"
+
+- name: "Add controlplane address to /etc/hosts"
+  ansible.builtin.lineinfile:
+    path: /etc/hosts
+    search_string: "cluster-endpoint"
+    line: "{{common_controlplane_ip}} cluster-endpoint"
+    owner: root
+    group: root
+    mode: '0644'
+  become: true

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -7,3 +7,5 @@
 - include_tasks: linux.yml
 
 - include_tasks: containerd.yml
+
+- include_tasks: k8s.yml

--- a/roles/common/vars/main.yml
+++ b/roles/common/vars/main.yml
@@ -1,5 +1,5 @@
 common_ansible_directory: "{{ansible_user_dir}}/.ansible"
-common_containerd_tar: "containerd-{{containerd_version}}-linux-amd64.tar.gz"
+common_containerd_tar: "containerd-{{common_containerd_version}}-linux-amd64.tar.gz"
 common_linux_modules:
   - overlay
   - br_netfilter

--- a/roles/common/vars/main.yml
+++ b/roles/common/vars/main.yml
@@ -3,3 +3,4 @@ common_containerd_tar: "containerd-{{common_containerd_version}}-linux-amd64.tar
 common_linux_modules:
   - overlay
   - br_netfilter
+common_k8s_keyring_path: /etc/apt/keyrings/kubernetes-apt-keyring.gpg


### PR DESCRIPTION
## Summary

This PR adds the tasks needed to install kubelet, kubeadm and kubectl.
It introduces the variable `common_controlplane_ip`, which is populated with the ip address of the first host with tag role=controlplane.
The variable is written to `/etc/hosts` under the entry cluster-endpoint, which is the address of the controlplane.

closes #2 